### PR TITLE
Add new client to get register data

### DIFF
--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -1,8 +1,11 @@
 require 'morph'
 require 'rest-client'
+require 'json'
+require 'registers_client'
+require 'register_client'
 
 module OpenRegister
-  VERSION = '0.0.1' unless defined? OpenRegister::VERSION
+  VERSION = '0.1.0' unless defined? OpenRegister::VERSION
 end
 
 class OpenRegister::Register
@@ -97,7 +100,6 @@ end
 
 module OpenRegister
   class << self
-
     def cache= cache
       @cache = cache
     end
@@ -141,7 +143,7 @@ module OpenRegister
       retrieve(url, register, base_url_or_phase, @cache)
     end
 
-    def versions register, record, base_url_or_phase=nil
+    def versions(register, record, base_url_or_phase = nil)
       if record.respond_to?(:_curie)
         object = record
         record = record._curie.split(':').last

--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -1,0 +1,108 @@
+require 'rest-client'
+require 'json'
+
+module OpenRegister
+  class RegisterClient
+    def initialize(register, phase)
+      @register = register
+      @phase = phase
+
+      refresh_data
+    end
+
+    def refresh_data
+      @items = []
+      @entries = { user: [], system: [] }
+      @records = { user: {}, system: {} }
+
+      rsf = download_rsf(@register, @phase)
+      parse_rsf(rsf)
+    end
+
+    def get_entries
+      @entries[:user]
+    end
+
+    def get_records
+      @records[:user].map { |_k, v| v.last }
+    end
+
+    def get_metadata_records
+      @records[:system].map { |_k, v| v.last }
+    end
+
+    def get_field_definitions
+      get_metadata_records.select { |record| record[:key].start_with?('field:') }
+    end
+
+    def get_register_definition
+      get_metadata_records.select { |record| record[:key].start_with?('register:') }.first
+    end
+
+    def get_custodian
+      get_metadata_records.select { |record| record[:key] == 'custodian'}.first
+    end
+
+    def get_records_with_history
+      @records[:user]
+    end
+
+    def get_current_records
+      get_records.select { |record| record[:item]['end-date'].blank? }
+    end
+
+    def get_expired_records
+      get_records.select { |record| record[:item]['end-date'].present? }
+    end
+
+    private
+
+    def download_rsf(register, phase)
+      RestClient.get("https://#{register}.#{phase}.openregister.org/download-rsf")
+    end
+
+    def parse_rsf(rsf)
+      rsf.each_line do |line|
+        line.slice!("\n")
+        params = line.split("\t")
+
+        command = params[0]
+
+        if command == 'add-item'
+          @items << parse_item(params[1])
+        elsif command == 'append-entry'
+          key = params[2]
+          entry_number = @entries[:user].count + 1
+          entry_timestamp = params[3]
+          current_item_hash = params[4]
+          record = parse_entry(key, entry_number, entry_timestamp, current_item_hash, JSON.parse(@items.find { |item| item[:hash] == current_item_hash }[:item]))
+
+          if params[1] == 'user'
+            if !@records[:user].key?(key)
+              @records[:user][key] = []
+            end
+
+            @records[:user][key] << record
+            @entries[:user] << record
+          else
+            if !@records[:system].key?(key)
+              @records[:system][key] = []
+            end
+
+            @records[:system][key] << record
+            @entries[:system] << record
+          end
+        end
+      end
+    end
+
+    def parse_item(item_json)
+      payload_sha = Digest::SHA256.hexdigest item_json
+      { hash: 'sha-256:' + payload_sha, item: item_json }
+    end
+
+    def parse_entry(key, entry_number, entry_timestamp, hash, current_item)
+      { key: key, entry_number: entry_number, timestamp: entry_timestamp, hash: hash, item: current_item }
+    end
+  end
+end

--- a/lib/registers_client.rb
+++ b/lib/registers_client.rb
@@ -1,0 +1,17 @@
+module OpenRegister
+  class RegistersClient
+    def initialize
+      @register_clients = {}
+    end
+
+    def get_register(register, phase)
+      key = register + ':' + phase
+
+      if !@register_clients.key?(key)
+        @register_clients[key] = OpenRegister::RegisterClient.new register, phase
+      end
+
+      @register_clients[key]
+    end
+  end
+end

--- a/openregister-ruby.gemspec
+++ b/openregister-ruby.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "openregister-ruby".freeze
-  s.version = "0.0.2"
+  s.version = "0.1.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
@@ -11,7 +11,7 @@ Gem::Specification.new do |s|
   s.date = "2016-07-18"
   s.email = "rob ~@nospam@~ rubyforge.org".freeze
   s.extra_rdoc_files = ["README.md".freeze]
-  s.files = ["Gemfile".freeze, "LICENSE".freeze, "README.md".freeze, "lib/openregister.rb".freeze]
+  s.files = ["Gemfile".freeze, "LICENSE".freeze, "README.md".freeze, "lib/openregister.rb".freeze, "lib/register_client.rb".freeze, "lib/registers_client.rb".freeze]
   s.homepage = "https://github.com/robmckinnon/openregister-ruby".freeze
   s.licenses = ["MIT".freeze]
   s.rdoc_options = ["--main".freeze, "README.md".freeze]


### PR DESCRIPTION
This PR adds functionality to allow clients to get the records, entries and metadata of registers without the need to make repeated API calls. In particular, it can deliver all the records of a register, only the current / expired / current & expired records of a register, and individual pieces of metadata such as the field and register definitions.