### PR TITLE
Cache register data

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,6 @@ group :test do
   end
   gem 'webmock'
 end
-
+gem 'mini_cache'
 gem 'morph', '>= 0.5.1'
 gem 'rest-client', '>= 2.0.1'

--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -1,34 +1,29 @@
 require 'rest-client'
 require 'json'
+require 'date'
+require 'mini_cache'
 
 module OpenRegister
   class RegisterClient
-    def initialize(register, phase)
+    def initialize(register, phase, config_options)
+      @store = MiniCache::Store.new
       @register = register
       @phase = phase
+      @config_options = config_options
 
-      refresh_data
-    end
-
-    def refresh_data
-      @items = []
-      @entries = { user: [], system: [] }
-      @records = { user: {}, system: {} }
-
-      rsf = download_rsf(@register, @phase)
-      parse_rsf(rsf)
+      get_data
     end
 
     def get_entries
-      @entries[:user]
+      get_data[:entries][:user]
     end
 
     def get_records
-      @records[:user].map { |_k, v| v.last }
+      get_data[:records][:user].map { |_k, v| v.last }
     end
 
     def get_metadata_records
-      @records[:system].map { |_k, v| v.last }
+      get_data[:records][:system].map { |_k, v| v.last }
     end
 
     def get_field_definitions
@@ -44,7 +39,7 @@ module OpenRegister
     end
 
     def get_records_with_history
-      @records[:user]
+      get_data[:records][:user]
     end
 
     def get_current_records
@@ -57,11 +52,23 @@ module OpenRegister
 
     private
 
+    def get_data
+      @store.get_or_set('data') do
+        rsf = download_rsf(@register, @phase)
+        data = parse_rsf(rsf)
+        MiniCache::Data.new(data, expires_in: @config_options[:cache_duration])
+      end
+    end
+
     def download_rsf(register, phase)
       RestClient.get("https://#{register}.#{phase}.openregister.org/download-rsf")
     end
 
     def parse_rsf(rsf)
+      items = []
+      entries = { user: [], system: [] }
+      records = { user: {}, system: {} }
+
       rsf.each_line do |line|
         line.slice!("\n")
         params = line.split("\t")
@@ -69,31 +76,33 @@ module OpenRegister
         command = params[0]
 
         if command == 'add-item'
-          @items << parse_item(params[1])
+          items << parse_item(params[1])
         elsif command == 'append-entry'
           key = params[2]
-          entry_number = @entries[:user].count + 1
+          entry_number = entries[:user].count + 1
           entry_timestamp = params[3]
           current_item_hash = params[4]
-          record = parse_entry(key, entry_number, entry_timestamp, current_item_hash, JSON.parse(@items.find { |item| item[:hash] == current_item_hash }[:item]))
+          record = parse_entry(key, entry_number, entry_timestamp, current_item_hash, JSON.parse(items.find { |item| item[:hash] == current_item_hash }[:item]))
 
           if params[1] == 'user'
-            if !@records[:user].key?(key)
-              @records[:user][key] = []
+            if !records[:user].key?(key)
+              records[:user][key] = []
             end
 
-            @records[:user][key] << record
-            @entries[:user] << record
+            records[:user][key] << record
+            entries[:user] << record
           else
-            if !@records[:system].key?(key)
-              @records[:system][key] = []
+            if !records[:system].key?(key)
+              records[:system][key] = []
             end
 
-            @records[:system][key] << record
-            @entries[:system] << record
+            records[:system][key] << record
+            entries[:system] << record
           end
         end
       end
+
+      { records: records, entries: entries, items: items }
     end
 
     def parse_item(item_json)

--- a/lib/registers_client.rb
+++ b/lib/registers_client.rb
@@ -1,6 +1,7 @@
 module OpenRegister
   class RegistersClient
-    def initialize
+    def initialize(config_options = {})
+      @config_options = defaults.merge(config_options)
       @register_clients = {}
     end
 
@@ -8,10 +9,18 @@ module OpenRegister
       key = register + ':' + phase
 
       if !@register_clients.key?(key)
-        @register_clients[key] = OpenRegister::RegisterClient.new register, phase
+        @register_clients[key] = OpenRegister::RegisterClient.new register, phase, @config_options
       end
 
       @register_clients[key]
+    end
+
+    private
+
+    def defaults
+      {
+          cache_duration: 30
+      }
     end
   end
 end

--- a/openregister-ruby.gemspec
+++ b/openregister-ruby.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "openregister-ruby".freeze
-  s.version = "0.1.0"
+  s.version = "0.2.0"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]
@@ -24,17 +24,20 @@ Gem::Specification.new do |s|
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<morph>.freeze, ["~> 0.5.0"])
       s.add_runtime_dependency(%q<rest-client>.freeze, ["~> 2"])
+      s.add_runtime_dependency(%q<mini_cache>.freeze, ["~> 1.1.0"])
       s.add_development_dependency(%q<guard-rspec>.freeze, ["~> 4"])
       s.add_development_dependency(%q<webmock>.freeze, ["~> 2"])
     else
       s.add_dependency(%q<morph>.freeze, ["~> 0.5.0"])
       s.add_dependency(%q<rest-client>.freeze, ["~> 2"])
+      s.add_dependency(%q<mini_cache>.freeze, ["~> 1.1.0"])
       s.add_dependency(%q<guard-rspec>.freeze, ["~> 4"])
       s.add_dependency(%q<webmock>.freeze, ["~> 2"])
     end
   else
     s.add_dependency(%q<morph>.freeze, ["~> 0.5.0"])
     s.add_dependency(%q<rest-client>.freeze, ["~> 2"])
+    s.add_dependency(%q<mini_cache>.freeze, ["~> 1.1.0"])
     s.add_dependency(%q<guard-rspec>.freeze, ["~> 4"])
     s.add_dependency(%q<webmock>.freeze, ["~> 2"])
   end


### PR DESCRIPTION
This commit adds mini_cache to the client library and uses it to cache results from the call to `/download-rsf` for a given `RegisterClient` object. The cache duration is configurable by the caller when creating a new `RegistersClient`; if no duration is specified by the caller, a default duration of one minute is assumed. All `RegisterClient`s will use the provided cache duration.