### PR TITLE
Add refresh_data method back to client

### DIFF
--- a/lib/register_client.rb
+++ b/lib/register_client.rb
@@ -50,6 +50,14 @@ module OpenRegister
       get_records.select { |record| record[:item]['end-date'].present? }
     end
 
+    def refresh_data
+      @store.set('data') do
+        rsf = download_rsf(@register, @phase)
+        data = parse_rsf(rsf)
+        MiniCache::Data.new(data, expires_in: @config_options[:cache_duration])
+      end
+    end
+
     private
 
     def get_data

--- a/openregister-ruby.gemspec
+++ b/openregister-ruby.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "openregister-ruby".freeze
-  s.version = "0.2.0"
+  s.version = "0.2.1"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]


### PR DESCRIPTION
This commit adds back to `RegisterClient` the `refresh_data` method, which a client can call manually if they wish to update the cache before it expires for the particular register data.