### PR TITLE
Escape URI path

### DIFF
--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -263,7 +263,7 @@ module OpenRegister
     end
 
     def url_for path, register, base_url_or_phase
-      escaped_path = URI.escape(path)
+      escaped_path = URI.escape(path.to_s)
       if base_url_or_phase
         host = case base_url_or_phase
                when Symbol

--- a/lib/openregister.rb
+++ b/lib/openregister.rb
@@ -263,6 +263,7 @@ module OpenRegister
     end
 
     def url_for path, register, base_url_or_phase
+      escaped_path = URI.escape(path)
       if base_url_or_phase
         host = case base_url_or_phase
                when Symbol
@@ -270,9 +271,9 @@ module OpenRegister
                when String
                  base_url_or_phase.sub('register', register.to_s).chomp('/')
                end
-        "#{host}/#{path}"
+        "#{host}/#{escaped_path}"
       else
-        "https://#{register}.register.gov.uk/#{path}"
+        "https://#{register}.register.gov.uk/#{escaped_path}"
       end
     end
 

--- a/openregister-ruby.gemspec
+++ b/openregister-ruby.gemspec
@@ -3,7 +3,7 @@
 
 Gem::Specification.new do |s|
   s.name = "openregister-ruby".freeze
-  s.version = "0.2.2"
+  s.version = "0.2.3"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0".freeze) if s.respond_to? :required_rubygems_version=
   s.require_paths = ["lib".freeze]

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -620,7 +620,14 @@ RSpec.describe OpenRegister do
           expect(entries.size).to eq 100
         end
       end
+
+      describe 'URI encoding' do
+        it 'URI encodes a key with spaces' do
+          url = OpenRegister.send(:url_for, 'foo bar', 'country', :beta)
+          expect(url).to eq'https://country.beta.openregister.org/foo%20bar'
+        end
+      end
+
     end
   end
-
 end

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -627,8 +627,14 @@ RSpec.describe OpenRegister do
           expect(url).to eq'https://country.beta.openregister.org/foo%20bar'
           expect(URI(url)).to be_instance_of(URI::HTTPS) 
         end
-      end
 
+        it 'Accepts a string as phase' do
+          url = OpenRegister.send(:url_for, 'record/SU.tsv', 'country', 'https://register.test.openregister.org')
+          expect(url).to eq'https://country.test.openregister.org/record/SU.tsv'
+          expect(URI(url)).to be_instance_of(URI::HTTPS) 
+        end
+      end
     end
   end
 end
+

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -625,6 +625,7 @@ RSpec.describe OpenRegister do
         it 'URI encodes a key with spaces' do
           url = OpenRegister.send(:url_for, 'foo bar', 'country', :beta)
           expect(url).to eq'https://country.beta.openregister.org/foo%20bar'
+          expect(URI(url)).to be_instance_of(URI::HTTPS) 
         end
       end
 

--- a/spec/lib/openregister_spec.rb
+++ b/spec/lib/openregister_spec.rb
@@ -117,6 +117,10 @@ RSpec.describe OpenRegister do
 
     stub_tsv_request('https://company.discovery.openregister.org/item/sha-256:6e21329956c6fa807e3a1a4fb5ce40a037917dfafbbeeeb45d2880745aef2850.tsv',
       './spec/fixtures/tsv/company-sha-256-6e21329956c6fa807e3a1a4fb5ce40a037917dfafbbeeeb45d2880745aef2850.tsv')
+
+    stub_tsv_request('https://country.alpha.openregister.org/record/foo%20bar.tsv',
+      './spec/fixtures/tsv/country-entries.tsv')
+  
   end
 
   describe 'retrieve registers index' do
@@ -632,6 +636,17 @@ RSpec.describe OpenRegister do
           url = OpenRegister.send(:url_for, 'record/SU.tsv', 'country', 'https://register.test.openregister.org')
           expect(url).to eq'https://country.test.openregister.org/record/SU.tsv'
           expect(URI(url)).to be_instance_of(URI::HTTPS) 
+        end
+      end
+           
+      describe 'record request with spaces' do
+        let(:register) { 'country' }
+        let(:record) { 'foo bar' }
+    
+        subject { OpenRegister.record(register, record, 'https://register.alpha.openregister.org/') }
+    
+        it 'returns encoded URI' do
+          expect(subject._uri).to eq('https://country.alpha.openregister.org/record/foo%20bar')
         end
       end
     end


### PR DESCRIPTION
## Before
Querying a key containing a non URL safe character such as a whitespace would cause an exception
```
> OpenRegister.record 'country', 'S U', :beta
URI::InvalidURIError: bad URI(is not URI?): https://country.beta.openregister.org/record/S U.tsv
```


## After 
The query is URL escaped

```
> OpenRegister.record 'country', 'S U', :beta
https://country.beta.openregister.org/record/S%20U.tsv - 404 Not Found
 => nil 

```